### PR TITLE
perf(fields): run fieldalignment --fix ./...

### DIFF
--- a/pkg/manifest/dependancy.go
+++ b/pkg/manifest/dependancy.go
@@ -8,6 +8,6 @@ type Dependency struct {
 	Name     string   `yaml:"name"`
 	Url      string   `yaml:"url"`
 	Version  string   `yaml:"version"`
-	Protocol Protocol `yaml:"protocol"`
 	CheckSum string   `yaml:"checksum"`
+	Protocol Protocol `yaml:"protocol"`
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Manifest struct {
+	Dependencies map[string]Dependency `yaml:"dependencies"`
 	Name         string                `yaml:"name"`
 	Version      string                `yaml:"version"`
-	Dependencies map[string]Dependency `yaml:"dependencies"`
 }
 
 func LoadManifestFile(path string) (*Manifest, error) {


### PR DESCRIPTION
Simply use the fieldalignment to reduce the memory impact of structs. This can also be done as part of golangci-lint, however I noticed that golangci-lint wasn't being run as part of hk